### PR TITLE
Sync action pins

### DIFF
--- a/.github/workflows/readme-stats.yaml
+++ b/.github/workflows/readme-stats.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Generate stats card
-        uses: readme-tools/github-readme-stats-action@b4d2ef3b8051484b318d455163153b23a2b35fa2 # v1.1.0
+        uses: readme-tools/github-readme-stats-action@f9d8133845f40d659a754f78b8484983ba766448 # v2.0.1
         with:
           card: stats
           options: username=kdeldycke&show_icons=true&text_color=718096&hide_title=true&rank_icon=percentile


### PR DESCRIPTION
## 🆙 Updated actions

Resolved with [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age) cooldown `8 days`: releases after `2026-07-09` are held back.

| Action | Change | Released |
| :-- | :-- | :-- |
| [readme-tools/github-readme-stats-action](https://github.com/readme-tools/github-readme-stats-action) | [`v1.1.0` → `v2.0.1`](https://github.com/readme-tools/github-readme-stats-action/compare/v1.1.0...v2.0.1) | 2026-06-19 (a month ago) |

### Release notes

<details>
<summary><code>readme-tools/github-readme-stats-action</code></summary>

#### [`v1.2.0`](https://github.com/readme-tools/github-readme-stats-action/releases/tag/v1.2.0)

Dependency upgrades and small internal improvements.

##### What's Changed
* permissions cleanup by @​martin-mfg in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/9
* update README with gist PAT info by @​martin-mfg in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/13
* security: pin SHA of GitHub Actions by @​hyperfinitism in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/15
* add dependabot by @​martin-mfg in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/16
* align with github-stats-extended by @​martin-mfg in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/22
* upgrade `prettier`, fix pipeline by @​martin-mfg in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/23
* upgrade `@actions/core` by @​martin-mfg in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/24
* build(deps-dev): bump lint-staged from 15.2.7 to 16.4.0 by @​dependabot[bot] in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/17
* build(deps-dev): bump husky from 9.0.11 to 9.1.7 by @​dependabot[bot] in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/26
* build(deps): bump @​actions/core from 3.0.0 to 3.0.1 by @​dependabot[bot] in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/37
* build(deps-dev): bump prettier from 3.8.1 to 3.8.3 by @​dependabot[bot] in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/33
* build(deps-dev): bump knip from 6.2.0 to 6.7.0 by @​dependabot[bot] in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/41
* ci(deps): bump actions/setup-node from 6.3.0 to 6.4.0 by @​dependabot[bot] in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/34

... [Full release notes](https://github.com/readme-tools/github-readme-stats-action/releases/tag/v1.2.0)

#### [`v2.0.0`](https://github.com/readme-tools/github-readme-stats-action/releases/tag/v2.0.0)

github-readme-stats-action now uses [github-stats-extended](https://redirect.github.com/stats-organization/github-stats-extended) internally, as an replacement for and extension of github-readme-stats.

##### What's Changed
* switch to github-stats-extended by @​martin-mfg in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/45


**Full Changelog**: https://redirect.github.com/stats-organization/github-readme-stats-action/compare/v1...v2.0.0

#### [`v2.0.1`](https://github.com/readme-tools/github-readme-stats-action/releases/tag/v2.0.1)

Dependency upgrades and small internal improvements.

##### What's Changed
* upgrade default version of github-stats-extended to 2.1.3
* fix: expose path as a composite action output by @​marcalexiei in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/65
* fix: avoid husky warning and dev deps on consumer installs by @​marcalexiei in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/64
* feat: source Node version from `package.json#engines`  by @​marcalexiei in https://redirect.github.com/stats-organization/github-readme-stats-action/pull/66
* small documentation updates
* dependency upgrades

</details>

## Configuration

Relevant [`[tool.repomatic]`](https://kdeldycke.github.io/repomatic/configuration.html) options:

- [`action-pins.sync`](https://kdeldycke.github.io/repomatic/configuration.html#action-pins-sync)
- [`minimum-release-age`](https://kdeldycke.github.io/repomatic/configuration.html#minimum-release-age)


> [!IMPORTANT]
> If you suspect the PR content is outdated, **[click `Run workflow`](https://github.com/kdeldycke/kdeldycke/actions/workflows/autofix.yaml)** to refresh it manually before merging.


<details><summary><code>Workflow metadata</code></summary>

- **Documentation**: [`sync-action-pins`](https://kdeldycke.github.io/repomatic/workflows.html#sync-action-pins-updater)
- **Trigger**: `push`
- **Actor**: @kdeldycke
- **Ref**: `main`
- **Commit**: [`3cb5bb20`](https://github.com/kdeldycke/kdeldycke/commit/3cb5bb20fcabccbe816444fd4ddff84fcfd79905)
- **Job**: [`sync-deps`](https://github.com/kdeldycke/kdeldycke/blob/3cb5bb20fcabccbe816444fd4ddff84fcfd79905/.github/workflows/autofix.yaml)
- **Workflow**: [`autofix.yaml`](https://github.com/kdeldycke/kdeldycke/blob/3cb5bb20fcabccbe816444fd4ddff84fcfd79905/.github/workflows/autofix.yaml)
- **Run**: [#27.1](https://github.com/kdeldycke/kdeldycke/actions/runs/29604572885)

</details>

---

🏭 Generated with [repomatic](https://github.com/kdeldycke/repomatic) `7.2.0`